### PR TITLE
Fix for ng-src and nonstandard RegExp.$2 property

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -18,7 +18,7 @@ directive('obLazytube', function($sce, $window, $templateCache, obLazytubeConfig
     link: function($scope, $element, $attrs) {
       var id = $attrs.obLazytube;
       if(!id) {
-        var url = $attrs.href || $attrs.src;
+        var url = $attrs.href || $attrs.src || $attrs.ngSrc;
         if(!url || !url.match(urlPattern)) {
           return;
         }

--- a/src/directive.js
+++ b/src/directive.js
@@ -19,10 +19,14 @@ directive('obLazytube', function($sce, $window, $templateCache, obLazytubeConfig
       var id = $attrs.obLazytube;
       if(!id) {
         var url = $attrs.href || $attrs.src || $attrs.ngSrc;
-        if(!url || !url.match(urlPattern)) {
+        if(!url) {
           return;
         }
-        id = RegExp.$2;
+        var r = url.match(urlPattern);
+        if (!r) {
+          return;
+        }
+        id = r[2];
       }
 
       $scope.id = id;


### PR DESCRIPTION
The ng-src fix is necessary when you have something like this:

``` html
<div ng-repeat="lesson in lesson_list">
  <iframe ob-lazytube width="640" height="360" ng-src="{{lesson.youtube}}" frameborder="0" allowfullscreen></iframe>
</div>
```

Also, the non-standard `RegExp.$2` property works inconsistently (at least on my browser: chromium 48.0.2564.103). I had issues with it when using URLs like `//youtube.com/embed/<ID>` whereas `https://youtube.com/embed/<ID>` worked correctly. I changed it in order to follow the standard, and now it seems to work consistently.
